### PR TITLE
Add character & weapon selection

### DIFF
--- a/Agent Baker Zombie Shooter/characterData.js
+++ b/Agent Baker Zombie Shooter/characterData.js
@@ -1,0 +1,35 @@
+export const characters = [
+  {
+    id: 'agent',
+    name: 'Agent Baker',
+    description: 'Balanced stats',
+    speed: 200,
+    maxHealth: 100,
+    shootCooldown: 0.5,
+    bulletSpread: 0.4,
+    portrait: '',
+    reloadTime: 1.0
+  },
+  {
+    id: 'investigator',
+    name: 'Investigator Baker',
+    description: 'Fast, low health, precise aim',
+    speed: 250,
+    maxHealth: 70,
+    shootCooldown: 0.4,
+    bulletSpread: 0.2,
+    portrait: '',
+    reloadTime: 0.8
+  },
+  {
+    id: 'tofu',
+    name: 'Bad Day Tofu',
+    description: 'High health, slow speed, close-range tank',
+    speed: 150,
+    maxHealth: 150,
+    shootCooldown: 0.6,
+    bulletSpread: 0.6,
+    portrait: '',
+    reloadTime: 1.2
+  }
+];

--- a/Agent Baker Zombie Shooter/game.js
+++ b/Agent Baker Zombie Shooter/game.js
@@ -18,9 +18,12 @@ import * as playerCombat from './player/playerCombat.js';
 const RESET_SHOOT_COOLDOWN_ON_RESUME = true;
 
 class Game {
-    constructor() {
+    constructor(options = {}) {
         this.canvas = document.getElementById('gameCanvas');
         this.ctx = this.canvas.getContext('2d');
+        this.selectedCharacter = options.character;
+        this.primaryWeapon = options.primaryWeapon;
+        this.secondaryWeapon = options.secondaryWeapon;
         
         this.preloadAssets();
         
@@ -64,13 +67,9 @@ class Game {
         this.resizeCanvas();
         
         // Game and Player Data
-        this.initGameData();
-        this.gameFlowManager = new GameFlowManager(this);
-        
         // Event Listeners
         this.setupGlobalEventListeners();
         
-        this.start();
     }
 
     preloadAssets() {
@@ -159,9 +158,13 @@ class Game {
     }
     
     initGameData() {
-        this.player = new Player(this.canvas.width / 2, this.canvas.height / 2);
+        const cfg = Object.assign({}, this.selectedCharacter, { primaryWeapon: this.primaryWeapon, secondaryWeapon: this.secondaryWeapon });
+        this.player = new Player(this.canvas.width / 2, this.canvas.height / 2, cfg);
         this.shopSystem = new ShopSystem(this.gameState, this.player, (name) => this.audioManager.play(name), this.powerupSystem);
         this.renderer.userZoom = 1.0;
+        this.gameState.selectedCharacter = this.selectedCharacter;
+        this.gameState.primaryWeapon = this.primaryWeapon;
+        this.gameState.secondaryWeapon = this.secondaryWeapon;
     }
     
     resizeCanvas() {
@@ -195,6 +198,7 @@ class Game {
         }
     }
     
+    
     restart() {
         this.audioManager.stopMusic();
         this.gameState.reset();
@@ -204,20 +208,21 @@ class Game {
         this.initGameData();
         this.renderer.sceneDrawer.reset();
 
-        // Reset zoom slider UI
-        const zoomSlider = document.getElementById('zoomSlider');
-        const zoomValue = document.getElementById('zoomValue');
+        const zoomSlider = document.getElementById("zoomSlider");
+        const zoomValue = document.getElementById("zoomValue");
         if (zoomSlider && zoomValue) {
             zoomSlider.value = 1.0;
-            zoomValue.textContent = '1.0x';
+            zoomValue.textContent = "1.0x";
         }
 
         this.gameFlowManager = new GameFlowManager(this);
-        this.gameState.isPaused = false; // Ensure game is not paused on restart
+        this.gameState.isPaused = false;
     }
-    
+
     start() {
         this.gameState.gameRunning = true;
+        this.initGameData();
+        this.gameFlowManager = new GameFlowManager(this);
         this.gameState.lastTime = performance.now();
         
         // Start paused
@@ -447,5 +452,3 @@ class Game {
     }
 }
 
-// Start the game
-new Game();

--- a/Agent Baker Zombie Shooter/gameState.js
+++ b/Agent Baker Zombie Shooter/gameState.js
@@ -17,6 +17,9 @@ export class GameState {
         /* @tweakable boss arena padding for boundaries during boss fights */
         this.bossArenaPadding = 100;
         
+        this.selectedCharacter = null;
+        this.primaryWeapon = null;
+        this.secondaryWeapon = null;
         this.gameRunning = false;
         this.isPaused = false;
         this.isGameOver = false;

--- a/Agent Baker Zombie Shooter/hudManager.js
+++ b/Agent Baker Zombie Shooter/hudManager.js
@@ -24,6 +24,9 @@ export class HudManager {
             finalStandContainer: document.getElementById('finalStandContainer'),
             finalStandIcon: document.getElementById('finalStandIcon'),
             finalStandCooldownFill: document.getElementById('finalStandCooldownFill'),
+            charName: document.getElementById("charName"),
+            primaryName: document.getElementById("primaryName"),
+            secondaryName: document.getElementById("secondaryName"),
         };
     }
 
@@ -43,6 +46,12 @@ export class HudManager {
         this.elements.score.textContent = score;
         this.elements.wave.textContent = wave;
     }
+    setCharacterInfo(name, primary, secondary) {
+        this.elements.charName.textContent = name;
+        this.elements.primaryName.textContent = primary;
+        this.elements.secondaryName.textContent = secondary;
+    }
+
 
     updateGrenadeUI(current, max) {
         const container = this.elements.grenadeContainer;

--- a/Agent Baker Zombie Shooter/index.html
+++ b/Agent Baker Zombie Shooter/index.html
@@ -22,7 +22,8 @@
                     <div class="xp-fill"></div>
                     <span class="xp-text">Level 1</span>
                 </div>
-                <div class="stats">
+                <div class="character-info"><span id="charName"></span> - <span id="primaryName"></span> / <span id="secondaryName"></span></div>
+            <div class="stats">
                     <div>Score: <span id="score">0</span></div>
                     <div>Wave: <span id="wave">1</span></div>
                 </div>
@@ -178,6 +179,22 @@
                 <p class="death-tip" id="deathTip"></p>
                 <button class="menu-btn" id="playAgainBtn">Play Again</button>
             </div>
+            <div class="character-selection" id="characterSelection">
+                <h2>Select Your Character</h2>
+                <div class="character-options" id="characterOptions"></div>
+            </div>
+            <div class="loadout-selection hidden" id="loadoutSelection">
+                <h2>Select Your Loadout</h2>
+                <div class="loadout-group">
+                    <h3>Primary Weapon</h3>
+                    <div class="weapon-options" id="primaryOptions"></div>
+                </div>
+                <div class="loadout-group">
+                    <h3>Secondary Weapon</h3>
+                    <div class="weapon-options" id="secondaryOptions"></div>
+                </div>
+                <button class="menu-btn" id="startGameBtn">Start Game</button>
+            </div>
             <div class="controls-hint">
                 <p>WASD to move • ESC to pause</p>
             </div>
@@ -241,6 +258,6 @@
         }
     }
     </script>
-    <script type="module" src="game.js"></script>
+    <script type="module" src="main.js"></script>
 </body>
 </html>

--- a/Agent Baker Zombie Shooter/main-ui.css
+++ b/Agent Baker Zombie Shooter/main-ui.css
@@ -56,6 +56,13 @@
     margin-bottom: 5px;
 }
 
+.character-info {
+    font-size: 16px;
+    font-weight: bold;
+    text-shadow: 1px 1px 2px rgba(0,0,0,0.8);
+}
+
+
 /* --- Bottom UI --- */
 .bottom-left-ui, .bottom-center-ui, .bottom-right-ui {
     position: absolute;

--- a/Agent Baker Zombie Shooter/main.js
+++ b/Agent Baker Zombie Shooter/main.js
@@ -1,0 +1,78 @@
+import { characters } from './characterData.js';
+import { primaryWeapons, secondaryWeapons } from './weaponData.js';
+import { Game } from './game.js';
+
+let selectedCharacter = null;
+let selectedPrimary = null;
+let selectedSecondary = null;
+let currentGame = null;
+
+function createOptionButton(item, container, onSelect) {
+  const btn = document.createElement('button');
+  btn.className = 'powerup-btn';
+  btn.innerHTML = `<h3>${item.name}</h3><p>${item.description || ''}</p>`;
+  btn.title = item.stats ?
+    `Damage: ${item.stats.damage}\nRate: ${item.stats.fireRate}s\nRange: ${item.stats.range}` : '';
+  btn.addEventListener('click', () => onSelect(item, btn));
+  container.appendChild(btn);
+  return btn;
+}
+
+function showCharacterSelection() {
+  const container = document.getElementById('characterOptions');
+  container.innerHTML = '';
+  characters.forEach(ch => {
+    createOptionButton(ch, container, (item, btn) => {
+      selectedCharacter = item;
+      [...container.children].forEach(c => c.classList.remove('selected'));
+      btn.classList.add('selected');
+      showLoadoutSelection();
+    });
+  });
+  document.getElementById('characterSelection').classList.remove('hidden');
+}
+
+function showLoadoutSelection() {
+  const pCont = document.getElementById('primaryOptions');
+  const sCont = document.getElementById('secondaryOptions');
+  pCont.innerHTML = '';
+  sCont.innerHTML = '';
+
+  primaryWeapons.forEach(w => {
+    createOptionButton(w, pCont, (item, btn) => {
+      selectedPrimary = item;
+      [...pCont.children].forEach(c => c.classList.remove('selected'));
+      btn.classList.add('selected');
+    });
+  });
+
+  secondaryWeapons.forEach(w => {
+    createOptionButton(w, sCont, (item, btn) => {
+      selectedSecondary = item;
+      [...sCont.children].forEach(c => c.classList.remove('selected'));
+      btn.classList.add('selected');
+    });
+  });
+
+  document.getElementById('characterSelection').classList.add('hidden');
+  document.getElementById('loadoutSelection').classList.remove('hidden');
+}
+
+function startGame() {
+  if (!selectedCharacter || !selectedPrimary || !selectedSecondary) return;
+  document.getElementById('loadoutSelection').classList.add('hidden');
+  currentGame = new Game({
+    character: selectedCharacter,
+    primaryWeapon: selectedPrimary,
+    secondaryWeapon: selectedSecondary
+  });
+  currentGame.start();
+  currentGame.uiManager.setCharacterInfo(selectedCharacter.name, selectedPrimary.name, selectedSecondary.name);
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  showCharacterSelection();
+  document.getElementById('startGameBtn').addEventListener('click', startGame);
+});
+
+export { startGame };

--- a/Agent Baker Zombie Shooter/popups.css
+++ b/Agent Baker Zombie Shooter/popups.css
@@ -1,5 +1,10 @@
 /* --- Common Popup Styles --- */
-.powerup-selection, .pause-menu, .death-screen, .shop-selection {
+.powerup-selection,
+.pause-menu,
+.death-screen,
+.shop-selection,
+.character-selection,
+.loadout-selection {
     position: absolute;
     top: 50%;
     left: 50%;
@@ -13,11 +18,21 @@
     z-index: 20;
 }
 
-.powerup-selection.hidden, .pause-menu.hidden, .death-screen.hidden, .shop-selection.hidden {
+.powerup-selection.hidden,
+.pause-menu.hidden,
+.death-screen.hidden,
+.shop-selection.hidden,
+.character-selection.hidden,
+.loadout-selection.hidden {
     display: none;
 }
 
-.powerup-selection h2, .pause-menu h2, .death-screen h2, .shop-selection h2 {
+.powerup-selection h2,
+.pause-menu h2,
+.death-screen h2,
+.shop-selection h2,
+.character-selection h2,
+.loadout-selection h2 {
     margin-bottom: 20px;
     font-size: 24px;
 }
@@ -58,6 +73,15 @@
     gap: 20px;
     justify-content: center;
 }
+.character-options, .weapon-options {
+    display: flex;
+    gap: 20px;
+    justify-content: center;
+}
+.loadout-group {
+    margin-bottom: 20px;
+}
+
 
 .powerup-btn {
     background: linear-gradient(145deg, #4a4a4a, #3a3a3a);
@@ -135,6 +159,10 @@
 }
 
 /* Highlight selected boss reward buttons */
+.powerup-btn.selected {
+    border-color: #44ff88;
+    box-shadow: 0 0 15px rgba(68, 255, 136, 0.5);
+}
 #bossRewardSelection .powerup-btn.selected {
     border-color: #44ff88;
     box-shadow: 0 0 15px rgba(68, 255, 136, 0.5);

--- a/Agent Baker Zombie Shooter/uiManager.js
+++ b/Agent Baker Zombie Shooter/uiManager.js
@@ -20,6 +20,10 @@ export class UIManager {
         this.hudManager.updateHealth(current, max);
     }
 
+    setCharacterInfo(name, primary, secondary) {
+        this.hudManager.setCharacterInfo(name, primary, secondary);
+    }
+
     updateXP(xp, xpRequired, level) {
         this.hudManager.updateXP(xp, xpRequired, level);
     }

--- a/Agent Baker Zombie Shooter/weaponData.js
+++ b/Agent Baker Zombie Shooter/weaponData.js
@@ -1,0 +1,95 @@
+export const primaryWeapons = [
+  {
+    id: 'pistol',
+    name: 'Pistol',
+    stats: {
+      damage: 25,
+      fireRate: 0.3,
+      bulletCount: 1,
+      spread: 0.2,
+      range: 250,
+      reload: 1.0,
+      ammo: 'light'
+    }
+  },
+  {
+    id: 'magnum',
+    name: 'Magnum',
+    stats: {
+      damage: 60,
+      fireRate: 0.8,
+      bulletCount: 1,
+      spread: 0.1,
+      range: 300,
+      reload: 1.5,
+      ammo: 'heavy'
+    }
+  },
+  {
+    id: 'smg',
+    name: 'SMG',
+    stats: {
+      damage: 15,
+      fireRate: 0.15,
+      bulletCount: 1,
+      spread: 0.3,
+      range: 220,
+      reload: 1.0,
+      ammo: 'light'
+    }
+  },
+  {
+    id: 'shotgun',
+    name: 'Shotgun',
+    stats: {
+      damage: 12,
+      fireRate: 0.9,
+      bulletCount: 5,
+      spread: 0.6,
+      range: 180,
+      reload: 1.5,
+      ammo: 'shell'
+    }
+  },
+  {
+    id: 'ar',
+    name: 'Assault Rifle',
+    stats: {
+      damage: 20,
+      fireRate: 0.25,
+      bulletCount: 1,
+      spread: 0.25,
+      range: 270,
+      reload: 1.2,
+      ammo: 'light'
+    }
+  }
+];
+
+export const secondaryWeapons = [
+  {
+    id: 'knife',
+    name: 'Combat Knife',
+    stats: { damage: 35, fireRate: 0.5, range: 60, reload: 0.3, ammo: 'melee' }
+  },
+  {
+    id: 'flare',
+    name: 'Flare Gun',
+    stats: { damage: 10, fireRate: 1.2, range: 180, reload: 1.5, ammo: 'flare' }
+  },
+  {
+    id: 'throwing_knives',
+    name: 'Throwable Knives',
+    stats: { damage: 20, fireRate: 0.6, range: 200, reload: 0.8, ammo: 'knife' }
+  },
+  {
+    id: 'grenade',
+    name: 'Grenade',
+    stats: { damage: 80, fireRate: 1.5, range: 150, reload: 2.0, ammo: 'explosive' }
+  },
+  {
+    id: 'taser',
+    name: 'Taser',
+    stats: { damage: 5, fireRate: 1.0, range: 100, reload: 1.0, ammo: 'shock' }
+  }
+];


### PR DESCRIPTION
## Summary
- add selectable characters and weapons via new screens
- display chosen loadout in top HUD
- restructure Game start flow to accept options
- create data modules for character and weapons
- update HUD management and styles for new UI
- fix selection screen bugs

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685d9ddbed9c832bac96af347e2e9a12